### PR TITLE
Added an instance variable for logger

### DIFF
--- a/rg_logger.rb
+++ b/rg_logger.rb
@@ -1,9 +1,11 @@
-# this is a mixin which is meant to add simple logging facilities to a class
+# this is a mixin which adds a simple logging facility to a class
 
 module RGLogger
   def set_logger(&block)
-    self.logger = block if block_given?
+    @logger = block if block_given?
   end
+
+  def logger; @logger end
 
   def log(msg)
     self.logger.call(msg) if self.logger

--- a/server.rb
+++ b/server.rb
@@ -5,19 +5,14 @@ class HTTPServer
   include RGLogger
   
   attr_reader :thread
-  attr_accessor :logger
   
   # Initialize a TCPServer object that will listen
   # on localhost:2345 for incoming connections.
   def initialize(host, port)
     @server = TCPServer.new(host, port)
     @handlers = []
-    @logger = nil
   end
 
-  # def logger(&block) @log = block end
-  # def log(msg) @log.call(msg) if @log end
-  
   def start
     # loop infinitely, processing one incoming
     # connection at a time.

--- a/tester.rb
+++ b/tester.rb
@@ -8,7 +8,6 @@ class Tester < Serial
   include RGLogger
 
   attr_reader :results
-  attr_accessor :logger
   
   def self.system_pipe3(pwd, cmd)
     values = nil
@@ -26,12 +25,11 @@ class Tester < Serial
     super()
     @results = { status: :init }
     @test = (block_given?) ? block : nil
-    @logger = nil
 
     @listener = Listen.to(*paths, ignore: /(^.?#|~$)/) do |mod, add, rem|
       test(mod, add, rem)
     end
-    Thread.start { test([ '*' ]) }
+    Thread.start { Thread.current[:name] = :test; test([ '*' ]) }
     @listener.start
   end
 


### PR DESCRIPTION
- logger needed an instance variable to store the block for the action to take when a log(msg) is called.  previously the instance variable was
  created in the object logger was mixed with.  The instance variable was moved to the mixin to eliminate some repetative coding.